### PR TITLE
JPA Auditing으로 생성시간/수정시간 자동화

### DIFF
--- a/src/main/java/com/fastcampus/pharmacy/BaseTimeEntity.java
+++ b/src/main/java/com/fastcampus/pharmacy/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.fastcampus.pharmacy;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/fastcampus/pharmacy/PharmacyProjectApplication.java
+++ b/src/main/java/com/fastcampus/pharmacy/PharmacyProjectApplication.java
@@ -2,7 +2,9 @@ package com.fastcampus.pharmacy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class PharmacyProjectApplication {
 

--- a/src/main/java/com/fastcampus/pharmacy/pharmacy/entity/Pharmacy.java
+++ b/src/main/java/com/fastcampus/pharmacy/pharmacy/entity/Pharmacy.java
@@ -1,5 +1,6 @@
 package com.fastcampus.pharmacy.pharmacy.entity;
 
+import com.fastcampus.pharmacy.BaseTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +17,7 @@ import javax.persistence.Id;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Pharmacy {
+public class Pharmacy extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/test/groovy/com/fastcampus/pharmacy/pharmacy/repository/PharmacyRepositoryTest.groovy
+++ b/src/test/groovy/com/fastcampus/pharmacy/pharmacy/repository/PharmacyRepositoryTest.groovy
@@ -4,6 +4,8 @@ import com.fastcampus.pharmacy.AbstractIntegrationContainerBaseTest
 import com.fastcampus.pharmacy.pharmacy.entity.Pharmacy
 import org.springframework.beans.factory.annotation.Autowired
 
+import java.time.LocalDateTime
+
 class PharmacyRepositoryTest extends AbstractIntegrationContainerBaseTest{
 
     @Autowired
@@ -58,6 +60,25 @@ class PharmacyRepositoryTest extends AbstractIntegrationContainerBaseTest{
 
         then:
         result.size() == 1
+    }
 
+    def "BaseTimeEntity 등록"() {
+        given:
+        LocalDateTime now = LocalDateTime.now()
+        String address = "서울 특별시 성북구 종암동"
+        String name = "은혜 약국"
+
+        def pharmacy = Pharmacy.builder()
+                .pharmacyAddress(address)
+                .pharmacyName(name)
+                .build()
+
+        when:
+        def save = pharmacyRepository.save(pharmacy)
+        def findPharmacy = pharmacyRepository.findById(save.getId()).orElse(null)
+
+        then:
+        findPharmacy.getCreatedDate().isAfter( now)
+        findPharmacy.getModifiedDate().isAfter(now)
     }
 }


### PR DESCRIPTION
JPA Auditing 기술을 사용해서 생성일시/수정일시를 자동으로 업데이트 되도록 구현함
`생성자/수정자`는 추후에 도입이 필요하다고 생각되면 추가할 예정.

This closes #8 