### PR TITLE
Spring Transactional 사용시 주의사항 테스트

### DIFF
--- a/src/main/java/com/fastcampus/pharmacy/pharmacy/service/PharmacyRepositoryService.java
+++ b/src/main/java/com/fastcampus/pharmacy/pharmacy/service/PharmacyRepositoryService.java
@@ -5,8 +5,10 @@ import com.fastcampus.pharmacy.pharmacy.repository.PharmacyRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import javax.transaction.Transactional;
+import java.util.List;
 import java.util.Objects;
 
 @RequiredArgsConstructor
@@ -15,6 +17,31 @@ import java.util.Objects;
 public class PharmacyRepositoryService {
 
     private final PharmacyRepository pharmacyRepository;
+
+    // self invocation test
+    @Transactional
+    public void bar(List<Pharmacy> pharmacyList) {
+        log.info("bar CurrentTransactionName: "+ TransactionSynchronizationManager.getCurrentTransactionName());
+        foo(pharmacyList);
+    }
+
+    // self invocation test
+    @Transactional
+    public void foo(List<Pharmacy> pharmacyList) {
+        log.info("foo CurrentTransactionName: "+ TransactionSynchronizationManager.getCurrentTransactionName());
+        pharmacyList.forEach(pharmacy -> {
+            pharmacyRepository.save(pharmacy);
+            throw new RuntimeException("error"); // 예외 발생
+        });
+    }
+
+
+    // read only test
+    @Transactional(readOnly = true)
+    public void startReadOnlyMethod(Long id) {
+        pharmacyRepository.findById(id).ifPresent(pharmacy ->
+                pharmacy.changePharmacyAddress("서울 특별시 광진구"));
+    }
 
     @Transactional
     public void updateAddress(Long id, String address) {
@@ -37,5 +64,10 @@ public class PharmacyRepositoryService {
         }
 
         entity.changePharmacyAddress(address);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Pharmacy> findAll() {
+        return pharmacyRepository.findAll();
     }
 }

--- a/src/test/groovy/com/fastcampus/pharmacy/pharmacy/service/PharmacyRepositoryServiceTest.groovy
+++ b/src/test/groovy/com/fastcampus/pharmacy/pharmacy/service/PharmacyRepositoryServiceTest.groovy
@@ -59,4 +59,29 @@ class PharmacyRepositoryServiceTest extends AbstractIntegrationContainerBaseTest
         then:
         result.get(0).getPharmacyAddress() == address
     }
+
+    def "transactional readOnly test - 읽기 전용일 경우 dirty checking 반영 되지 않는다. "() {
+
+        given:
+        String inputAddress = "서울 특별시 성북구"
+        String modifiedAddress = "서울 특별시 광진구"
+        String name = "은혜 약국"
+        double latitude = 36.11
+        double longitude = 128.11
+
+        def input = Pharmacy.builder()
+                .pharmacyAddress(inputAddress)
+                .pharmacyName(name)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build()
+
+        when:
+        def pharmacy = pharmacyRepository.save(input)
+        pharmacyRepositoryService.startReadOnlyMethod(pharmacy.id)
+
+        then:
+        def result = pharmacyRepositoryService.findAll()
+        result.get(0).getPharmacyAddress() == inputAddress
+    }
 }


### PR DESCRIPTION
__`JPA에서 데이터 변경은 모두 트랜잭션 안에서 이루어져야 한다.`__
`@Transactional`은 기본적으로 쓰기 전용으로 설정되어있고, 
조회만 하는 경우에는 `읽기 전용(readonly=true)`로 설정하면 성능상 이점을 얻을 수 있다.
`@Transactional`은 클래스와 메서드에 선언할 수 있고, 클래스와 메서드에 모두 선언되어있는 경우 메서드의 우선순위가 더 높다.

This closes #10 