### PR TITLE
Redis로 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,31 +25,29 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.3.4'
-
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // https://github.com/seruco/base62
     implementation 'io.seruco.encoding:base62:0.1.3'
-
     // spring retry
     implementation 'org.springframework.retry:spring-retry'
 
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     // mockWebServer
     testImplementation('com.squareup.okhttp3:okhttp:4.10.0')
     testImplementation('com.squareup.okhttp3:mockwebserver:4.10.0')
-
     // spock
     testImplementation('org.spockframework:spock-core:2.1-groovy-3.0')
     testImplementation('org.spockframework:spock-spring:2.1-groovy-3.0')
-
     // 런타임에 클래스 기반 spock mock을 만들기 위해서 필요
     testImplementation('net.bytebuddy:byte-buddy:1.12.10')
-
     // testcontainers
     testImplementation 'org.testcontainers:spock:1.17.1'
     testImplementation 'org.testcontainers:mariadb:1.17.1'

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -8,7 +8,7 @@ services:
     # 도커 허브 id를 앞에 붙여준 이유는 도커 허브에 push 할 때 어떤 repo에 push 할지 찾지 못하기 때문에 명시함
     image: ddmkim94/pharmacy-recommendation-redis
     ports:
-    - "6379:6379" # redis 기본 포트는 6379
+      - "6379:6379" # redis 기본 포트는 6379
   pharmacy-recommendation-database:
     container_name: pharmacy-recommendation-database
     build:
@@ -19,7 +19,7 @@ services:
       - MARIADB_DATABASE=pharmacy-recommendation
       - MARIADB_ROOT_PASSWORD=${SPRING_DATASOURCE_PASSWORD} # 외부에서 주입 (.env 파일로 작성 -> 도커 컴포즈가 실행될 때 읽어서 주입)
     volumes:
-    - ./database/config:/etc/config/conf.d # mariadb.cnf 를 참조해서 conf.d 초기화를 진행
-    - ./database/init:/docker-entrypoint-initdb.d
+      - ./database/config:/etc/config/conf.d # mariadb.cnf 를 참조해서 conf.d 초기화를 진행
+      - ./database/init:/docker-entrypoint-initdb.d
     ports:
-    - "3306:3306" # mariadb 기본 포트는 3306
+      - "3306:3306" # mariadb 기본 포트는 3306

--- a/src/main/java/com/fastcampus/pharmacy/config/ObjectMapperConfig.java
+++ b/src/main/java/com/fastcampus/pharmacy/config/ObjectMapperConfig.java
@@ -1,0 +1,14 @@
+package com.fastcampus.pharmacy.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/com/fastcampus/pharmacy/config/RedisConfig.java
+++ b/src/main/java/com/fastcampus/pharmacy/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.fastcampus.pharmacy.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/fastcampus/pharmacy/pharmacy/cache/PharmacyRedisTemplateService.java
+++ b/src/main/java/com/fastcampus/pharmacy/pharmacy/cache/PharmacyRedisTemplateService.java
@@ -36,12 +36,10 @@ public class PharmacyRedisTemplateService {
         }
 
         try {
-            hashOperations.put(
-                    CACHE_KEY,
-                    String.valueOf(pharmacyDto.getId()),
-                    serializePharmacyDto(pharmacyDto)
-            );
-            log.info("[PharmacyRedisTemplateService save success] id: {}", pharmacyDto.getId());
+            hashOperations.put(CACHE_KEY,
+                    pharmacyDto.getId().toString(),
+                    serializePharmacyDto(pharmacyDto));
+            log.info("[PharmacyRedisTemplateService save success] key: {}, id: {}",CACHE_KEY, pharmacyDto.getId());
         } catch (Exception e) {
             log.error("[PharmacyRedisTemplateService save error] {}", e.getMessage());
         }

--- a/src/main/java/com/fastcampus/pharmacy/pharmacy/cache/PharmacyRedisTemplateService.java
+++ b/src/main/java/com/fastcampus/pharmacy/pharmacy/cache/PharmacyRedisTemplateService.java
@@ -1,0 +1,80 @@
+package com.fastcampus.pharmacy.pharmacy.cache;
+
+import com.fastcampus.pharmacy.pharmacy.entity.dto.PharmacyDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PharmacyRedisTemplateService {
+
+    private static final String CACHE_KEY = "PHARMACY";
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private HashOperations<String, String, String> hashOperations;
+
+    // 생성자 주입 이후에 초기화
+    @PostConstruct
+    public void init() {
+        this.hashOperations = redisTemplate.opsForHash();
+    }
+
+    public void save(PharmacyDto pharmacyDto) {
+        if(Objects.isNull(pharmacyDto) || Objects.isNull(pharmacyDto.getId())) {
+            log.error("Required Values must not be null");
+            return;
+        }
+
+        try {
+            hashOperations.put(
+                    CACHE_KEY,
+                    String.valueOf(pharmacyDto.getId()),
+                    serializePharmacyDto(pharmacyDto)
+            );
+            log.info("[PharmacyRedisTemplateService save success] id: {}", pharmacyDto.getId());
+        } catch (Exception e) {
+            log.error("[PharmacyRedisTemplateService save error] {}", e.getMessage());
+        }
+    }
+
+    public List<PharmacyDto> findAll() {
+        try {
+            List<PharmacyDto> list = new ArrayList<>();
+            for (String value : hashOperations.entries(CACHE_KEY).values()) {
+                PharmacyDto pharmacyDto = deserializePharmacyDto(value);
+                list.add(pharmacyDto);
+            }
+
+            return list;
+        } catch (Exception e) {
+            log.error("[PharmacyRedisTemplateService findAll error]: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    public void delete(Long id) {
+        hashOperations.delete(CACHE_KEY, String.valueOf(id));
+        log.info("[PharmacyRedisTemplateService delete]: {} ", id);
+    }
+
+
+    // PharmacyDto -> JSON 으로 변환 (serialize)
+    private String serializePharmacyDto(PharmacyDto pharmacyDto) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(pharmacyDto);
+    }
+
+    // JSON -> PharmacyDto 로 변환 (deserialize)
+    private PharmacyDto deserializePharmacyDto(String value) throws JsonProcessingException {
+        return objectMapper.readValue(value, PharmacyDto.class);
+    }
+}

--- a/src/main/java/com/fastcampus/pharmacy/pharmacy/controller/PharmacyController.java
+++ b/src/main/java/com/fastcampus/pharmacy/pharmacy/controller/PharmacyController.java
@@ -1,0 +1,42 @@
+package com.fastcampus.pharmacy.pharmacy.controller;
+
+import com.fastcampus.pharmacy.pharmacy.cache.PharmacyRedisTemplateService;
+import com.fastcampus.pharmacy.pharmacy.entity.dto.PharmacyDto;
+import com.fastcampus.pharmacy.pharmacy.service.PharmacyRepositoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class PharmacyController {
+
+    private final PharmacyRepositoryService pharmacyRepositoryService;
+    private final PharmacyRedisTemplateService pharmacyRedisTemplateService;
+
+    // 데이터 초기 셋팅을 위한 임시 메서드
+    @GetMapping("/redis/save")
+    public String save() {
+
+        List<PharmacyDto> pharmacyDtoList = pharmacyRepositoryService.findAll()
+                .stream()
+                .map(pharmacy -> PharmacyDto.builder()
+                        .id(pharmacy.getId())
+                        .pharmacyName(pharmacy.getPharmacyName())
+                        .pharmacyAddress(pharmacy.getPharmacyAddress())
+                        .latitude(pharmacy.getLatitude())
+                        .longitude(pharmacy.getLongitude())
+                        .build())
+                .collect(Collectors.toList());
+
+        // Redis 에 데이터 저장
+        pharmacyDtoList.forEach(pharmacyRedisTemplateService::save);
+
+        return "success";
+    }
+}

--- a/src/main/java/com/fastcampus/pharmacy/pharmacy/service/PharmacySearchService.java
+++ b/src/main/java/com/fastcampus/pharmacy/pharmacy/service/PharmacySearchService.java
@@ -1,5 +1,6 @@
 package com.fastcampus.pharmacy.pharmacy.service;
 
+import com.fastcampus.pharmacy.pharmacy.cache.PharmacyRedisTemplateService;
 import com.fastcampus.pharmacy.pharmacy.entity.Pharmacy;
 import com.fastcampus.pharmacy.pharmacy.entity.dto.PharmacyDto;
 import lombok.RequiredArgsConstructor;
@@ -15,11 +16,18 @@ import java.util.stream.Collectors;
 public class PharmacySearchService {
 
     private final PharmacyRepositoryService pharmacyRepositoryService;
+    private final PharmacyRedisTemplateService pharmacyRedisTemplateService;
 
-    // redis
-
-    // db
     public List<PharmacyDto> searchPharmacyDtoList() {
+
+        // failover 처리
+        // redis
+        List<PharmacyDto> pharmacyDtoList = pharmacyRedisTemplateService.findAll();
+        if (!pharmacyDtoList.isEmpty()) {
+            return pharmacyDtoList;
+        }
+
+        // db
         return pharmacyRepositoryService.findAll()
                 .stream()
                 .map(this::convertToPharmacyDto)

--- a/src/main/java/com/fastcampus/pharmacy/pharmacy/service/PharmacySearchService.java
+++ b/src/main/java/com/fastcampus/pharmacy/pharmacy/service/PharmacySearchService.java
@@ -24,6 +24,7 @@ public class PharmacySearchService {
         // redis
         List<PharmacyDto> pharmacyDtoList = pharmacyRedisTemplateService.findAll();
         if (!pharmacyDtoList.isEmpty()) {
+            log.info("redis findAll success!");
             return pharmacyDtoList;
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,15 +30,12 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
   redis:
-    host: local
+    host: localhost
     port: 6379
   jpa:
     hibernate:
       ddl-auto: validate # create 옵션은 개발 환경에서만 사용하자! 운영 환경에서는 none
     show-sql: true # 실행 쿼리를 보여줌
-    properties:
-      hibernate:
-        format_sql: true
 
 pharmacy:
   recommendation:

--- a/src/test/groovy/com/fastcampus/pharmacy/pharmacy/cache/PharmacyRedisTemplateServiceTest.groovy
+++ b/src/test/groovy/com/fastcampus/pharmacy/pharmacy/cache/PharmacyRedisTemplateServiceTest.groovy
@@ -1,0 +1,72 @@
+package com.fastcampus.pharmacy.pharmacy.cache
+
+import com.fastcampus.pharmacy.AbstractIntegrationContainerBaseTest
+import com.fastcampus.pharmacy.pharmacy.entity.dto.PharmacyDto
+import org.springframework.beans.factory.annotation.Autowired
+
+class PharmacyRedisTemplateServiceTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private PharmacyRedisTemplateService pharmacyRedisTemplateService
+
+    def setup() {
+        pharmacyRedisTemplateService.findAll()
+            .forEach(dto -> pharmacyRedisTemplateService.delete(dto.getId()))
+    }
+
+    def "save success"() {
+        given:
+        String pharmacyName = "name"
+        String pharmacyAddress = "address"
+        PharmacyDto dto =
+                PharmacyDto.builder()
+                        .id(1L)
+                        .pharmacyName(pharmacyName)
+                        .pharmacyAddress(pharmacyAddress)
+                        .build()
+
+        when:
+        pharmacyRedisTemplateService.save(dto)
+        List<PharmacyDto> result = pharmacyRedisTemplateService.findAll()
+
+        then:
+        result.size() == 1
+        result.get(0).id == 1L
+        result.get(0).pharmacyName == pharmacyName
+        result.get(0).pharmacyAddress == pharmacyAddress
+    }
+
+    def "success fail"() {
+        given:
+        PharmacyDto dto =
+                PharmacyDto.builder()
+                        .build()
+
+        when:
+        pharmacyRedisTemplateService.save(dto)
+        List<PharmacyDto> result = pharmacyRedisTemplateService.findAll()
+
+        then:
+        result.size() == 0
+    }
+
+    def "delete"() {
+        given:
+        String pharmacyName = "name"
+        String pharmacyAddress = "address"
+        PharmacyDto dto =
+                PharmacyDto.builder()
+                        .id(1L)
+                        .pharmacyName(pharmacyName)
+                        .pharmacyAddress(pharmacyAddress)
+                        .build()
+
+        when:
+        pharmacyRedisTemplateService.save(dto)
+        pharmacyRedisTemplateService.delete(dto.getId())
+        def result = pharmacyRedisTemplateService.findAll()
+
+        then:
+        result.size() == 0
+    }
+}

--- a/src/test/groovy/com/fastcampus/pharmacy/pharmacy/cache/RedisTemplateTest.groovy
+++ b/src/test/groovy/com/fastcampus/pharmacy/pharmacy/cache/RedisTemplateTest.groovy
@@ -1,0 +1,60 @@
+package com.fastcampus.pharmacy.pharmacy.cache
+
+import com.fastcampus.pharmacy.AbstractIntegrationContainerBaseTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.redis.core.RedisTemplate
+
+class RedisTemplateTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private RedisTemplate redisTemplate
+
+
+    def "RedisTemplate String Operations"() {
+        given:
+        def valueOperations = redisTemplate.opsForValue()
+        def key = "stringKey"
+        def value = "hello"
+
+        when:
+        valueOperations.set(key, value) // 저장
+
+        then:
+        def result = valueOperations.get(key)
+        result == value
+    }
+
+    def "RedisTemplate Set Operations"() {
+        given:
+        def setOperations = redisTemplate.opsForSet()
+        def key = "setKey"
+
+        when:
+        setOperations.add(key, "h", "e", "l", "l", "o")
+
+        then:
+        def size = setOperations.size(key)
+        size == 4
+
+    }
+
+    def "RedisTemplate Hash Operations"() {
+        given:
+        def hashOperations = redisTemplate.opsForHash()
+        def key = "hashKey"
+
+        when:
+        hashOperations.put(key, "subKey", "value")
+
+        then:
+        def result = hashOperations.get(key, "subKey")
+        result == "value"
+
+        def entries = hashOperations.entries(key)
+        entries.keySet().contains("subKey")
+        entries.values().contains("value")
+
+        def size = hashOperations.size(key)
+        size == entries.size()
+    }
+}

--- a/src/test/groovy/com/fastcampus/pharmacy/pharmacy/service/PharmacySearchServiceTest.groovy
+++ b/src/test/groovy/com/fastcampus/pharmacy/pharmacy/service/PharmacySearchServiceTest.groovy
@@ -1,0 +1,45 @@
+package com.fastcampus.pharmacy.pharmacy.service
+
+import com.fastcampus.pharmacy.pharmacy.cache.PharmacyRedisTemplateService
+import com.fastcampus.pharmacy.pharmacy.entity.Pharmacy
+import org.assertj.core.util.Lists
+import spock.lang.Specification
+
+class PharmacySearchServiceTest extends Specification {
+
+    private PharmacySearchService pharmacySearchService
+
+    private PharmacyRepositoryService pharmacyRepositoryService = Mock()
+    private PharmacyRedisTemplateService pharmacyRedisTemplateService = Mock()
+
+    private List<Pharmacy> pharmacyList
+
+    def setup() {
+        pharmacySearchService = new PharmacySearchService(pharmacyRepositoryService, pharmacyRedisTemplateService)
+        pharmacyList = Lists.newArrayList(
+                Pharmacy.builder()
+                        .id(1L)
+                        .pharmacyName("호수온누리약국")
+                        .latitude(37.60894036)
+                        .longitude(127.029052)
+                        .build(),
+                Pharmacy.builder()
+                        .id(2L)
+                        .pharmacyName("돌곶이온누리약국")
+                        .latitude(37.61040424)
+                        .longitude(127.0569046)
+                        .build())
+
+    }
+
+    def "레디스 장애시 DB를 이용하여 약국 데이터 조회"() {
+        when:
+        pharmacyRedisTemplateService.findAll() >> Collections.emptyList() // []
+        pharmacyRepositoryService.findAll() >> pharmacyList
+
+        def result = pharmacySearchService.searchPharmacyDtoList()
+
+        then:
+        result.size() == 2
+    }
+}


### PR DESCRIPTION
레디스에 약국 데이터가 있을 경우 레디스에서 값을 가지고 오도록 변경
레디스 조회시 에러가 발생하면 원래대로 DB에서 조회함 `(failover)`

현재 카카오 API 를 사용해서 약국 위치를 받아오기 때문에 레디스를 사용하지 않음
레디스 동작 확인을 위해 공공 데이터를 사용하는 방식으로 테스트만 진행함

This closes #27 